### PR TITLE
Change ServerImpl#getGroupById to use group.getId()

### DIFF
--- a/src/main/java/discord/jar/ServerImpl.java
+++ b/src/main/java/discord/jar/ServerImpl.java
@@ -32,7 +32,7 @@ public class ServerImpl implements Server {
 
     @Override
     public Group getGroupById(String id) {
-        for (Group group : getGroups()) if (group.equals(id)) return group;
+        for (Group group : getGroups()) if (group.getId().equals(id)) return group;
         return null;
     }
 


### PR DESCRIPTION
The original implementation of getGroupById was to use group.equals(), which returns false since GroupImpl doesn't override equals. This is consistent with the way getting a group user is returned.

This should fix a NPE that occurs when any part of a channel is updated, which is thrown in ChannelUpdatedEvent