### PR TITLE
Change NewContactOrGroupPoll to send ChannelCreateEvent

### DIFF
--- a/src/main/java/discord/jar/NewContactOrGroupPoll.java
+++ b/src/main/java/discord/jar/NewContactOrGroupPoll.java
@@ -31,7 +31,7 @@ public class NewContactOrGroupPoll implements Poll {
             GroupImpl group = new GroupImpl(content.getString("id"), content.getString("id"), server, api);
             group.setName(content.getString("name"));
             server.getGroups().add(group);
-            api.getEventManager().executeEvent(new ChannelDeletedEvent(group));
+            api.getEventManager().executeEvent(new ChannelCreatedEvent(group));
         }
     }
 }


### PR DESCRIPTION
Another small tidbit to change, NewContactOrGroupPoll sends a ChannelDeleteEvent when a new channel is created. This should be changed to ChannelCreateEvent.